### PR TITLE
Flush callbacks and trajectory

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,6 +85,9 @@ struct StoreCallbacks{V} <: Algorithm
 end
 
 function StoreCallbacks(chains, path, steps; callbacks=missing)
+    if ismissing(callbacks)
+        callbacks = []
+    end
     return StoreCallbacks(callbacks, path)
 end
 
@@ -98,6 +101,7 @@ end
 function make_step!(simulation::Simulation, algorithm::StoreCallbacks)
     for (callback, file) in zip(algorithm.callbacks, algorithm.files)
         println(file, "$(simulation.t) $(callback(simulation))")
+        flush(file)
     end
 end
 
@@ -145,6 +149,7 @@ end
 function make_step!(simulation::Simulation, algorithm::StoreTrajectories)
     for c in eachindex(simulation.chains)
         store_trajectory(algorithm.files[c], simulation.chains[c], simulation.t)
+        flush(algorithm.files[c])
     end
 end
 


### PR DESCRIPTION
The problem of #31 was that the buffer waited to fill before flushing. Typically the size of the buffer is of `64 KB` but I have a hard time believe it was the case for the system.
The solution of this problem is to **flush** at each `make_step!` of algorithms that stores data. Closes #31