### PR TITLE
Add ForwardDiff backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -15,6 +16,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Enzyme = "0.12.36"
+ForwardDiff = "0.10.38"
 julia = "1.9"
 
 [extras]

--- a/src/PolicyGuided/PolicyGuided.jl
+++ b/src/PolicyGuided/PolicyGuided.jl
@@ -1,12 +1,13 @@
 module PolicyGuided
 
 using ..MonteCarlo: Action, Policy, Algorithm, Simulation
-import ..MonteCarlo: make_step!, sample_action!, perform_action!, delta_log_target_density, log_proposal_density, invert_action!, perform_action_cached!
+import ..MonteCarlo: make_step!, sample_action!, perform_action!, delta_log_target_density, log_proposal_density, invert_action!, perform_action_cached!, raise_error
 using Random
 using LinearAlgebra
 using Transducers
-using Enzyme: autodiff, ReverseWithPrimal, Const, Duplicated
-using Zygote: withgradient
+using Enzyme
+using Zygote
+using ForwardDiff
 
 include("gradients.jl")
 include("learning.jl")

--- a/test/ad_backends_test.jl
+++ b/test/ad_backends_test.jl
@@ -1,0 +1,26 @@
+using MonteCarlo
+using Test
+
+include("../example/particle_1d/particle_1d.jl")
+
+potential(x) = x^2
+
+seed = 42
+rng = Xoshiro(seed)
+β = 2.0
+system = System(4rand(rng) - 2, β)
+action = Displacement(0.0)
+policy = StandardGaussian()
+parameters = ComponentArray(σ=0.2)
+
+∇logq_Zygote = zero(parameters)
+∇logq_Enzyme = zero(parameters)
+∇logq_FD = zero(parameters)
+
+logq_Zygote = MonteCarlo.PolicyGuided.withgrad_log_proposal_density!(∇logq_Zygote, action, policy, parameters, system, MonteCarlo.PolicyGuided.Zygote_Backend(); shadow=deepcopy(system))
+logq_Enzyme = MonteCarlo.PolicyGuided.withgrad_log_proposal_density!(∇logq_Enzyme, action, policy, parameters, system, MonteCarlo.PolicyGuided.Enzyme_Backend(); shadow=deepcopy(system))
+logq_FD = MonteCarlo.PolicyGuided.withgrad_log_proposal_density!(∇logq_FD, action, policy, parameters, system, MonteCarlo.PolicyGuided.ForwardDiff_Backend(); shadow=deepcopy(system))
+
+@test isapprox(logq_Zygote, logq_Enzyme, atol=1e-10) && isapprox(logq_Zygote, logq_FD, atol=1e-10)
+@test isapprox(∇logq_Zygote, ∇logq_Enzyme, atol=1e-10) && isapprox(∇logq_Zygote, ∇logq_FD, atol=1e-10)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,3 +7,7 @@ end
 @safetestset "PGMC Test" begin
     include("pgmc_test.jl")
 end
+
+@safetestset "PGMG AD Backends" begin
+    include("ad_backends_test.jl")
+end


### PR DESCRIPTION
On top of Zygote (which is super slow in our case, don't know why) and Enzyme (which is not the friendlier package and which fails with certain moves). I think ForwardDiff is the lightest AD package in Julia, but it's not well suited for neural networks. In the future we could make this a default and make Zygote and Enzyme extensions.