### PR TITLE
From pools to pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ By modifying and extending the existing particle_1D.jl example, you can create a
 
 We welcome contributions from the community. If you have a new system or feature to add, please fork the repository, make your changes, and submit a pull request.
 
-## Citing MonteCarlo
+## Citing
 
 If you use MonteCarlo in your research, please cite it! You can find the citation information in the [CITATION](CITATION.cff) file or directly through GitHub’s "Cite this repository" button.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ temperature = 0.5
 β = 1/temperature
 M = 10
 chains = [System(x0, β) for _ in 1:M]
-pools = [(Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),) for _ in 1:M]
+pool = (Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),)
 steps = 10^5
 burn = 1000
 block = [0, 10]
@@ -53,7 +53,7 @@ sampletimes = build_schedule(steps, burn, block)
 path = "data/MC/particle_1d/Harmonic/beta$β/M$M/seed$seed"
 
 algorithm_list = (
-    (algorithm=Metropolis, pools=pools, seed=seed, parallel=false),
+    (algorithm=Metropolis, pool=pool, seed=seed, parallel=false),
     (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
     (algorithm=StoreTrajectories, scheduler=sampletimes),
 ) 

--- a/example/particle_1d/harmonic_oscillator/MC_harmonic_oscillator.jl
+++ b/example/particle_1d/harmonic_oscillator/MC_harmonic_oscillator.jl
@@ -11,7 +11,7 @@ rng = Xoshiro(seed)
 β = 2.0
 M = 10
 chains = [System(4rand(rng) - 2, β) for _ in 1:M]
-pools = [(Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),) for _ in 1:M]
+pool = (Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),)
 steps = 10^5
 burn = 1000
 block = [0, 10]
@@ -19,7 +19,7 @@ sampletimes = build_schedule(steps, burn, block)
 path = "data/MC/particle_1d/Harmonic/beta$β/M$M/seed$seed"
 
 algorithm_list = (
-    (algorithm=Metropolis, pools=pools, seed=seed, parallel=false),
+    (algorithm=Metropolis, pool=pool, seed=seed, parallel=false),
     (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
     (algorithm=StoreTrajectories, scheduler=sampletimes),
     (algorithm=StoreBackups, scheduler=build_schedule(steps, burn, steps ÷ 10), store_first=true, store_last=true),

--- a/example/particle_1d/harmonic_oscillator/PGMC_harmonic_oscillator.jl
+++ b/example/particle_1d/harmonic_oscillator/PGMC_harmonic_oscillator.jl
@@ -11,10 +11,10 @@ rng = Xoshiro(seed)
 β = 2.0
 M = 10
 chains = [System(4rand(rng) - 2, β) for _ in 1:M]
-pools = [(
+pool = (
     Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.2), 0.6),
     Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 0.4),
-) for _ in 1:M]
+) 
 optimisers = (Static(), VPG(0.001))
 steps = 10^5
 burn = 1000
@@ -22,12 +22,12 @@ block = [0, 10]
 sampletimes = build_schedule(steps, burn, block)
 path = "data/PGMC/particle_1d/Harmonic/beta$β/M$M/seed$seed"
 algorithm_list = (
-    (algorithm=Metropolis, pools=pools, seed=seed, parallel=false),
-    (algorithm=PolicyGradientEstimator, pools=pools, optimisers=optimisers, seed=seed, parallel=false),
+    (algorithm=Metropolis, pool=pool, seed=seed, parallel=false),
+    (algorithm=PolicyGradientEstimator, dependencies=(Metropolis,), optimisers=optimisers, parallel=false),
     (algorithm=PolicyGradientUpdate, dependencies=(PolicyGradientEstimator,)),
     (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
     (algorithm=StoreTrajectories, scheduler=sampletimes),
-    (algorithm=StoreParameters, pools=pools, scheduler=sampletimes),
+    (algorithm=StoreParameters, dependencies=(Metropolis,), scheduler=sampletimes),
     (algorithm=StoreLastFrames, scheduler=[steps]),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),
 )

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -22,4 +22,5 @@ export Simulation, run!
 export TXT, DAT
 
 include("PolicyGuided/PolicyGuided.jl")
+
 end

--- a/src/PolicyGuided/PolicyGuided.jl
+++ b/src/PolicyGuided/PolicyGuided.jl
@@ -1,6 +1,6 @@
 module PolicyGuided
 
-using ..MonteCarlo: Action, Policy, Algorithm, Simulation
+using ..MonteCarlo: Action, Policy, Algorithm, Simulation, Metropolis
 import ..MonteCarlo: make_step!, write_algorithm, sample_action!, perform_action!, delta_log_target_density, log_proposal_density, invert_action!, perform_action_cached!, raise_error
 using Random
 using LinearAlgebra

--- a/src/PolicyGuided/estimator.jl
+++ b/src/PolicyGuided/estimator.jl
@@ -63,7 +63,11 @@ struct PolicyGradientEstimator{P,O,VPL<:AbstractArray,VPR<:AbstractArray,VO<:Abs
 
 end
 
-function PolicyGradientEstimator(chains; pools=missing, optimisers=missing, q_batch_size=1, ad_backend=ForwardDiff_Backend(), seed=1, R=Xoshiro, parallel=false, extras...)
+function PolicyGradientEstimator(chains; dependencies=missing, optimisers=missing, q_batch_size=1, ad_backend=ForwardDiff_Backend(), R=Xoshiro, parallel=false, extras...)
+    @assert length(dependencies) == 1
+    @assert isa(dependencies[1], Metropolis)
+    metropolis = dependencies[1]
+    pools, seed = metropolis.pools, metropolis.seed
     return PolicyGradientEstimator(chains, pools, optimisers; q_batch_size=q_batch_size, ad_backend=ad_backend, seed=seed, R=R, parallel=parallel)
 end
 

--- a/test/distribution_test.jl
+++ b/test/distribution_test.jl
@@ -16,10 +16,10 @@ potential(x) = x^2
     sampletimes = build_schedule(steps, burn, block)
     for β in [2.0, 2.5, 3.0]
         chains = [System(4rand(rng) - 2, β) for _ in 1:M]
-        pools = [(Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),) for _ in 1:M]
+        pool = (Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),)
         path = "data/MC/particle_1d/Harmonic/beta$β/M$M/seed$seed"
         algorithm_list = (
-            (algorithm=Metropolis, pools=pools, seed=seed, parallel=false),
+            (algorithm=Metropolis, pool=pool, seed=seed, parallel=false),
             (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
             (algorithm=StoreTrajectories, scheduler=sampletimes),
             (algorithm=StoreBackups, scheduler=build_schedule(steps, burn, steps ÷ 10), store_first=true, store_last=true),

--- a/test/pgmc_test.jl
+++ b/test/pgmc_test.jl
@@ -14,7 +14,7 @@ potential(x) = x^2
     M = 10
     chains = [System(4rand(rng) - 2, β) for _ in 1:M]
     σ₀ = 0.2
-    pools = [(
+    pool = (
         Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=σ₀), 0.4),
         Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=σ₀), 0.1),
         Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=σ₀), 0.1),
@@ -22,7 +22,7 @@ potential(x) = x^2
         Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=σ₀), 0.1),
         Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=σ₀), 0.1),
         Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=σ₀), 0.1),
-    ) for _ in 1:M]
+    )
     optimisers = (Static(), VPG(0.001), BLPG(0.001), BLAPG(1e-6, 1e-6), NPG(1e-2, 1e-6), ANPG(1e-6, 1e-6), BLANPG(1e-6, 1e-6))
     steps = 10^5
     burn = 1000
@@ -30,12 +30,12 @@ potential(x) = x^2
     sampletimes = build_schedule(steps, burn, block)
     path = "data/PGMC/particle_1d/Harmonic/beta$β/M$M/seed$seed"
     algorithm_list = (
-        (algorithm=Metropolis, pools=pools, seed=seed, parallel=false),
-        (algorithm=PolicyGradientEstimator, pools=pools, optimisers=optimisers, q_batch_size=10, seed=seed, parallel=true),
+        (algorithm=Metropolis, pool=pool, seed=seed, parallel=false),
+        (algorithm=PolicyGradientEstimator, dependencies=(Metropolis,), optimisers=optimisers, q_batch_size=10, parallel=true),
         (algorithm=PolicyGradientUpdate, dependencies=(PolicyGradientEstimator,), scheduler=build_schedule(steps, burn, 2)),
         (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
         (algorithm=StoreTrajectories, scheduler=sampletimes),
-        (algorithm=StoreParameters, pools=pools, scheduler=sampletimes),
+        (algorithm=StoreParameters, dependencies=(Metropolis,), scheduler=sampletimes),
         (algorithm=StoreLastFrames, scheduler=[steps]),
         (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),
     )


### PR DESCRIPTION
The constructor for pools was a bit cumbersome: we needed to do

`pools = [(Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),) for _ in 1:M]`

which is ok, but not very user friendly. I modified the constructor for `Metropolis` to accept a single pool instead

`pool = (Move(Displacement(0.0), StandardGaussian(), ComponentArray(σ=0.1), 1.0),)`

Note that now the PGMC algorithms need to depend on `Metropolis` so that they reference to the same pools. This is something that we should have probably done before anyway.